### PR TITLE
chore: update documentation link to best-practices.8004scan.io

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -10,7 +10,7 @@ body:
       value: |
         ## Have a question?
 
-        We're happy to help! Please check our [documentation](https://docs.8004scan.io) first, as your question might already be answered there.
+        We're happy to help! Please check our [best practices guide](https://best-practices.8004scan.io/) first, as your question might already be answered there.
 
         **Before submitting**, please search [existing issues](https://github.com/alt-research/8004scan-issue-tracker/issues?q=label%3Aquestion) to see if your question has already been asked.
 
@@ -91,7 +91,7 @@ body:
       label: Resources Checked
       description: Please confirm you've checked these resources
       options:
-        - label: I have checked the [documentation](https://docs.8004scan.io)
+        - label: I have checked the [best practices guide](https://best-practices.8004scan.io/)
           required: true
         - label: I have searched existing issues for similar questions
           required: true


### PR DESCRIPTION
## Summary
- Updated documentation links in issue templates from `docs.8004scan.io` to `best-practices.8004scan.io`
- Fix https://github.com/alt-research/8004scan-issue-tracker/issues/4

## Changes
- `question.yml`: Updated 2 links to point to the new best practices documentation URL